### PR TITLE
feat: add errors to response context with AddError

### DIFF
--- a/graph/schema.resolvers.go
+++ b/graph/schema.resolvers.go
@@ -8,12 +8,15 @@ import (
 	"context"
 	"fmt"
 	"gql-gen-errorhandling/graph/model"
+
+	"github.com/99designs/gqlgen/graphql"
 )
 
 // Meow is the resolver for the meow field.
 func (r *catResolver) Meow(ctx context.Context, obj *model.Cat) (string, error) {
 	if obj.ID == "1" {
-		return "meow unavailable", fmt.Errorf("meow error. cat id: %s cannot meow.", obj.ID)
+		graphql.AddError(ctx, fmt.Errorf("meow error. cat id: %s cannot meow.", obj.ID))
+		return "meow unavailable", nil
 	}
 
 	res := fmt.Sprintf("%s the cat says meow.", obj.Name)


### PR DESCRIPTION
This example shows adding errors to the response context, via `graphql.AddError`.

This allows us to represent error states in the response object, while allowing us to maintain the integrity of the data schema, and represent any data type that we expect to be non-nullable to exist.


<img width="1606" alt="Screenshot 2024-10-21 at 14 33 40" src="https://github.com/user-attachments/assets/5a3d539a-a4aa-4e2e-adfb-06c5b45941f7">

